### PR TITLE
fix: 영상파일 not found 버그 수정

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -2,6 +2,8 @@ class GCS:
     SIGNED_URL_EXPIRE = 60 * 24
 
 class MESSAGES:
+    class SUCCESS:
+        ANALYZE = "영상 분석을 완료했습니다."
     class ERROR:
         NOT_FOUND_VIDEO = "영상을 찾을 수 없습니다."
         FAILED_ANALYZE = "영상 분석에 실패했습니다."
@@ -11,7 +13,3 @@ class MESSAGES:
         FAILED_CONNECT_CHANNEL = "채널 연결에 실패했습니다."
 
         SERVER_ERROR = "서버 오류가 발생했습니다."
-
-class ANALYZE_RESULT:
-    SUCCESS = "success"
-    FAILED = "failed"

--- a/src/gcs/read.py
+++ b/src/gcs/read.py
@@ -6,7 +6,8 @@ from config.gcs import get_bucket
 def get_video(file_name, save_dir):
     try:
         bucket = get_bucket()
-        blob = bucket.blob(f"edited/{file_name}.mp4")
+        blob_name = f"edited/{file_name}"
+        blob = bucket.blob(blob_name)
 
         blob.download_to_filename(os.path.join(save_dir, f"{file_name}.mp4"))
     except:

--- a/src/rabbitmq/consume.py
+++ b/src/rabbitmq/consume.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 
 from analyze_video import analyze_video
-from config.constants import ANALYZE_RESULT
+from config.constants import MESSAGES
 from config.rabbitmq import get_channel
 from gcs.generate_signed_url import generate_signed_url
 from gcs.read import get_video
@@ -25,7 +25,7 @@ def callback(ch, method, properties, body):
             signed_url = generate_signed_url(file_name=file_name)
             message = {
                 "email": email,
-                "message": ANALYZE_RESULT.SUCCESS,
+                "message": MESSAGES.SUCCESS.ANALYZE,
                 "url": signed_url
             }
         except Exception as err:
@@ -34,7 +34,6 @@ def callback(ch, method, properties, body):
                 "message": str(err),
                 "url": ""
             }
-
         publish_message(message=message)
 
         ch.basic_ack(delivery_tag=method.delivery_tag)


### PR DESCRIPTION
## #️⃣ Issue Number #8

## 🚅 PR 요약

GCS에 저장된 파일명과 코드의 파일명이 불일치하여 영상을 찾지 못하는 버그 수정

## TO-DO 체크리스트

- [x] 파일 이름에서 확장자를 제거합니다.
- [x] 기능이 올바르게 동작해야 합니다.

## 🧑‍💻 PR 세부 내용

GCS에서 영상을 가져오려고 시도했으나, 실제 파일명과 코드 상의 파일명이 일치하지 않아서 가져오지 못하는 버그가 있었습니다.

저장된 파일명 : test12345
찾은 파일명 : test12345.mp4

파일을 찾을 때 확장자를 제거하고 찾는 방식으로 수정하였습니다.

📸 스크린샷 (에러 메시지)

![image](https://github.com/user-attachments/assets/240173d2-66bf-4f27-bef0-6d10309c5705)

✅ PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
