### PR TITLE
feat: publish 메시지에 분석 성공/실패 코드 추가 - close #14

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -16,3 +16,9 @@ class MESSAGES:
         FAILED_CREATE_SUBTITLE = "자막 파일 생성에 실패했습니다."
         FAILED_CONNECT_CHANNEL = "채널 연결에 실패했습니다."
         SERVER_ERROR = "서버 오류가 발생했습니다."
+
+class CODE:
+    class SUCCESSS:
+        ANALYZE = "SUCCESS_ANALYZE"
+    class FAILED:
+        ANALYZE = "FAILED_ANALYZE"

--- a/src/rabbitmq/consume.py
+++ b/src/rabbitmq/consume.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from analyze_video import analyze_frame
-from config.constants import MESSAGES
+from config.constants import MESSAGES, CODE
 from gcs.generate_signed_url import generate_signed_url
 from gcs.read import get_video
 from gcs.write import upload_video
@@ -48,6 +48,7 @@ def process_message(body):
         signed_url = generate_signed_url(file_name=file_name)
         message = {
             "email": email,
+            "code": CODE.SUCCESSS.ANALYZE,
             "message": MESSAGES.SUCCESS.ANALYZE,
             "url": signed_url
         }
@@ -57,8 +58,9 @@ def process_message(body):
     except Exception as err:
         message = {
             "email": email,
+            "code": CODE.FAILED.ANALYZE,
             "message": str(err),
-            "url": ""
+            "url": None
         }
 
     return message


### PR DESCRIPTION
## #️⃣ Issue Number #14

## 🚅 PR 요약

이메일 템플릿 성공/실패 분기를 위한 코드 추가

## TO-DO 체크리스트

- [x] rabbitMQ publish 메시지에 성공 코드 메시지가 응답 메시지에 포함되어야 한다.
- [x] rabbitMQ publish 메시지에 실패 코드 메시지가 응답 메시지에 포함되어야 한다.

## 🧑‍💻 PR 세부 내용

- 기존에는 `url === ""` 여부로 성공/실패 여부를 판별했으나, express(큐 구독자) 측에서 성공/실패에 대한 명확한 구분을 위해 code 필드를 추가했습니다.
- AI 서버에서 code를 포함한 메시지를 발행하도록 변경하고, Express 서버는 해당 값을 기반으로 이메일 템플릿을 분기 처리합니다.

## 💬 공유사항 to 리뷰어

CODE 메시지가 express측과 동일한지 한 번 확인 부탁드립니다.

✅ PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드 컨벤션에 맞게 작성했습니다.
